### PR TITLE
replaced an empty server uuid on post with generated uuid

### DIFF
--- a/routes/servers.js
+++ b/routes/servers.js
@@ -30,7 +30,7 @@ router.post("/new", (req, res) => {
   if (!server.title) {
     res.send({ error: "server must have a title" });
   } else {
-    serversDb.data.servers.push({ id: nanoid(), ...server });
+    serversDb.data.servers.push({ ...server, id: nanoid() });
     serversDb
       .write()
       .then(() => {


### PR DESCRIPTION
Previously when a new server was submitted, an id would be assigned before the req data was added to the server object. Since the req data includes an id value, it was overwriting the generated value.

The req data is now inserted into the object before an id is generated for it.